### PR TITLE
Make 'View Logs' visible

### DIFF
--- a/BluetoothBatteryMonitor/UI/SettingsWindow.xaml
+++ b/BluetoothBatteryMonitor/UI/SettingsWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Bluetooth Battery Monitor — Settings"
-        Width="420" Height="340"
+        Width="420" Height="360"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterScreen"
         ShowInTaskbar="True"
@@ -88,7 +88,14 @@
             <TextBlock Style="{StaticResource DescriptionLabel}"
                        Text="Verbosity of the log file. Changes apply on next launch."/>
             <TextBlock Style="{StaticResource DescriptionLabel}" Margin="0,4,0,0">
-                <Hyperlink Click="ViewLogs_Click">View Logs</Hyperlink>
+                <Hyperlink Click="ViewLogs_Click">
+                    <Hyperlink.Style>
+                        <Style TargetType="Hyperlink">
+                            <Setter Property="TextDecorations" Value="None"/>
+                        </Style>
+                    </Hyperlink.Style>
+                    View Logs
+                </Hyperlink>
             </TextBlock>
 
             <!-- Auto-Start -->


### PR DESCRIPTION
The dialog box needs to be taller so the View Logs hyperlink is not cropped